### PR TITLE
Add deferStart to ghost-town options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Requires Node 4+ and PhantomJS 2.1+.
 * `pageCount`: Number of pages to process at a time. If your processing is mostly asynchronous (vs. e.g. render blocked), increasing this is recommended. Default: `1`.
 * `pageDeath`: Number of milliseconds to wait before before requeuing an item. If your processing is time-sensitive, decreasing this is recommended. Default: `30000`.
 * `pageTries`: Number of times to retry items that have timed out. If your processing could fail forever, configuring this is recommended. Default: `-1` (unlimited).
+* `deferStart`: Do not start ghost-town on creation, allowing defered startup. Default: `false`.
 
 Starts Ghost Town and returns a `Master` or a `Worker` instance exposing the following.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cluster = require("cluster");
+const cluster = require("recluster");
 const events = require("events");
 const phantom = require("phantom");
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class Master extends events.EventEmitter {
         
         cluster.on("exit", this._onExit.bind(this));
         
-        this.start();
+        !opts.deferStart &&  this.start();
     }
     
     _onMessage (msg) {

--- a/package.json
+++ b/package.json
@@ -1,23 +1,28 @@
 {
-    "name": "ghost-town",
-    "version": "3.0.0",
-    "description": "Simple queued & clustered PhantomJS processing.",
-    "keywords": ["cluster", "phantomjs", "queue"],
-    "homepage": "https://github.com/Buzzvil/ghost-town",
-    "bugs": "https://github.com/Buzzvil/ghost-town/issues",
-    "license": "MIT",
-    "author": "Teddy Cross <teddy@teddy.io> (https://teddy.io)",
-    "main": "./index",
-    "repository": "Buzzvil/ghost-town",
-    "scripts": {
-        "test": "mocha -R list -s 60s"
-    },
-    "dependencies": {
-        "phantom": "~2.1.12"
-    },
-    "devDependencies": {
-        "async": "~2.0.0",
-        "chai": "~3.5.0",
-        "mocha": "~2.5.3"
-    }
+  "name": "ghost-town",
+  "version": "3.0.0",
+  "description": "Simple queued & clustered PhantomJS processing.",
+  "keywords": [
+    "cluster",
+    "phantomjs",
+    "queue"
+  ],
+  "homepage": "https://github.com/Buzzvil/ghost-town",
+  "bugs": "https://github.com/Buzzvil/ghost-town/issues",
+  "license": "MIT",
+  "author": "Teddy Cross <teddy@teddy.io> (https://teddy.io)",
+  "main": "./index",
+  "repository": "Buzzvil/ghost-town",
+  "scripts": {
+    "test": "mocha -R list -s 60s"
+  },
+  "dependencies": {
+    "phantom": "~2.1.12",
+    "recluster": "^0.4.5"
+  },
+  "devDependencies": {
+    "async": "~2.0.0",
+    "chai": "~3.5.0",
+    "mocha": "~2.5.3"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -40,6 +40,11 @@ if (cluster.isMaster) {
         this.timeout(5000);
         
         describe("constructor", function () {
+            it("should defer start()", function () {
+                let town = ghost({deferStart: true});
+                expect(town.isRunning).to.equal(false);
+            });
+
             it("should support workerCount", function () {
                 ghost({ workerCount: 8 });
                 


### PR DESCRIPTION
I would like to defer starting ghost-town until after I've init'd the object, so I added an option to do so. There is a corresponding test for it.

FWIW I'm unsure just what the merge problem is, aside maybe from github freaking on the markdown for some reason.... (shrug)
